### PR TITLE
MT-003: Add Docker Compose for PostgreSQL, MongoDB, Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:latest
+    container_name: meratodo-postgres
+    environment:
+      POSTGRES_USER: meratodo
+      POSTGRES_PASSWORD: meratodo123
+      POSTGRES_DB: meratodo
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  mongo:
+    image: mongo:latest
+    container_name: meratodo-mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: meratodo
+      MONGO_INITDB_ROOT_PASSWORD: meratodo123
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+  redis:
+    image: redis:latest
+    container_name: meratodo-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+volumes:
+  postgres_data:
+  mongo_data:
+  redis_data:


### PR DESCRIPTION
Implements MT-003: Adds a `docker-compose.yml` file to manage PostgreSQL, MongoDB, and Redis containers for the meratodo-backend. Includes environment variables, port mappings, and volume configurations for persistent data.